### PR TITLE
Add `weekStartDate` attribute to partition date

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -55,6 +55,12 @@ function setProperty(object, key, value) {
     })
 }
 
+function getMondayOfWeek(date) {
+    const deltaDays = (date.getDay()+6)%7
+    const monday = new Date(date.getTime() - (deltaDays*1000*60*60*24))
+    return `${monday.getFullYear()}-${padNum(monday.getMonth()+1)}-${padNum(monday.getDate())}`
+}
+
 exports.handler = async (event, context) => {
     try {
         if (event.body) {
@@ -69,8 +75,10 @@ exports.handler = async (event, context) => {
                     throw new Error(`Missing required property: ${key}`)
                 }
             })
-
-            item.createdAt = (new Date()).toISOString()
+            const createdAt = new Date()
+            item.createdAt = createdAt.toISOString()
+            item.weekStartDate = getMondayOfWeek(createdAt)
+            
             item.ip = (event.requestContext && event.requestContext.http)
                 ? sha256(event.requestContext.http.sourceIp)
                 : 'unknown'


### PR DESCRIPTION
This adds a new attribute to the items stored in dynamodb - `weekStartDate`. This is the date string (`yyyy-mm-dd`) of the *Monday* at the start of the current week.

Once we retrospectively add this to the existing entries in the db, we can create a new secondary index that uses this as its partition key. That will make it much easier to query the data to get entries for a given week.

There isn't a clean way to get 'the last 7 days worth', but with this approach if you calculate the last two Monday dates, you can use those to query the new index and get the last week + a bit of entries.

---

The alternative approach is to scrap dynamodb and move to RDS. Having spent some time researching, there's a lot of needless, fiddly, complication around getting a lambda to write to RDS which will take a day or two to get right.

It will also increase our costs for this service from $0/month (as we're well inside free-tier for dynamo) to $30+/month for a minimally spec'd RDS. I appreciate that isn't a huge cost, but combined with the development cost of migrating, I don't think its worth the cost at this point in time.

I think we can address our main issues with dynamodb by getting the data architecture right - something I didn't properly understand when I first set this up.

Now we know the main type of query we want to run - generating stats per week - then this PR gives us that ability in a much more scalable way.