### PR TITLE
Improve schema for PG

### DIFF
--- a/database-schema.sql
+++ b/database-schema.sql
@@ -1,7 +1,7 @@
 --- This is the schema used to create the pings table
 
 CREATE TABLE "pings" (
-   "createdAt" TIMESTAMP not null,
+   "created_at" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
    "weekYear" varchar(12),
    "weekStartDate" TIMESTAMP,
    "instanceId" varchar(256),

--- a/database-schema.sql
+++ b/database-schema.sql
@@ -20,5 +20,6 @@ CREATE TABLE "pings" (
    "platform.counts.projectTemplates" INTEGER,
    "platform.config.broker.enabled" BOOLEAN,
    "platform.config.email.enabled" BOOLEAN,
-   "platform.config.fileStore.enabled" BOOLEAN
+   "platform.config.fileStore.enabled" BOOLEAN,
+   PRIMARY KEY ("created_at", "instanceId")
 )

--- a/database-schema.sql
+++ b/database-schema.sql
@@ -4,7 +4,6 @@ CREATE TABLE "pings" (
    "created_at" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
    "instanceId" varchar(256),
    "ip" varchar(256),
-   "isDev" BOOLEAN,
    "env.flowforge" varchar(64),
    "env.nodejs" varchar(64),
    "os.arch" varchar(32),

--- a/database-schema.sql
+++ b/database-schema.sql
@@ -2,8 +2,6 @@
 
 CREATE TABLE "pings" (
    "created_at" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-   "weekYear" varchar(12),
-   "weekStartDate" TIMESTAMP,
    "instanceId" varchar(256),
    "ip" varchar(256),
    "isDev" BOOLEAN,

--- a/migrations/20230105-default-createAt.sql
+++ b/migrations/20230105-default-createAt.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "pings" RENAME COLUMN "createdAt" TO "created_at";
+ALTER TABLE "pings" ALTER COLUMN "created_at" SET DEFAULT CURRENT_TIMESTAMP;

--- a/migrations/20230106-drop-week-identifiers.sql
+++ b/migrations/20230106-drop-week-identifiers.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "pings" DROP COLUMN "weekYear";
+ALTER TABLE "pings" DROP COLUMN "weekStartDate";

--- a/migrations/20230107-add-primary-key.sql
+++ b/migrations/20230107-add-primary-key.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "pings" ADD PRIMAY KEY ("created_at", "instanceId");

--- a/migrations/20230107-drop-is-dev.sql
+++ b/migrations/20230107-drop-is-dev.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "pings" DROP COLUMN "isDev";

--- a/src/app.js
+++ b/src/app.js
@@ -31,7 +31,6 @@ const optionalProperties = [
 
 const dbColumns = [
     'ip',
-    'isDev',
     ...requiredProperties,
     ...optionalProperties
 ]
@@ -99,9 +98,6 @@ exports.handler = async (event, context) => {
                 const value = getProperty(payload, key)
                 if (value !== undefined) {
                     setProperty(item, key, value)
-                    if (key === 'env.flowforge') {
-                        item.isDev = !!/git/.test(value)
-                    }
                 }
             })
 

--- a/src/app.js
+++ b/src/app.js
@@ -31,8 +31,6 @@ const optionalProperties = [
 
 const dbColumns = [
     'ip',
-    'weekYear',
-    'weekStartDate',
     'isDev',
     ...requiredProperties,
     ...optionalProperties
@@ -75,16 +73,6 @@ function setProperty(object, key, value) {
     })
 }
 
-function padNum(v) {
-    return ((v < 10)?'0':'')+v
-}
-
-function getMondayOfWeek(date) {
-    const deltaDays = (date.getDay()+6)%7
-    const monday = new Date(date.getTime() - (deltaDays*1000*60*60*24))
-    return `${monday.getFullYear()}-${padNum(monday.getMonth()+1)}-${padNum(monday.getDate())}`
-}
-
 exports.handler = async (event, context) => {
     const response = {
         'statusCode': 200
@@ -102,9 +90,7 @@ exports.handler = async (event, context) => {
                     throw new Error(`Missing required property: ${key}`)
                 }
             })
-            const createdAt = new Date()
-            item.weekStartDate = getMondayOfWeek(createdAt)
-            
+
             item.ip = (event.requestContext && event.requestContext.http)
                 ? sha256(event.requestContext.http.sourceIp)
                 : 'unknown'

--- a/src/app.js
+++ b/src/app.js
@@ -30,7 +30,6 @@ const optionalProperties = [
 ]
 
 const dbColumns = [
-    'createdAt',
     'ip',
     'weekYear',
     'weekStartDate',
@@ -41,11 +40,7 @@ const dbColumns = [
 
 const columnList = `"${dbColumns.join('","')}"`
 const columnValues = dbColumns.map((v,index) => {
-    if (index === 0) {
-        return 'current_timestamp'
-    } else {
-        return '$'+index
-    }
+	return '$'+index
 }).join(",")
 
 function getProperty(payload, key) {
@@ -108,7 +103,6 @@ exports.handler = async (event, context) => {
                 }
             })
             const createdAt = new Date()
-            item.createdAt = createdAt.toISOString()
             item.weekStartDate = getMondayOfWeek(createdAt)
             
             item.ip = (event.requestContext && event.requestContext.http)
@@ -137,7 +131,7 @@ exports.handler = async (event, context) => {
             try {
                 await client.connect();
 
-                const values = dbColumns.slice(1).map(v => {
+                const values = dbColumns.map(v => {
                     const value = getProperty(item, v)
                     if (value !== undefined) {
                         return value

--- a/src/app.js
+++ b/src/app.js
@@ -38,7 +38,7 @@ const dbColumns = [
 
 const columnList = `"${dbColumns.join('","')}"`
 const columnValues = dbColumns.map((v,index) => {
-	return '$'+index
+	return '$'+(index+1)
 }).join(",")
 
 function getProperty(payload, key) {

--- a/test/app_spec.js
+++ b/test/app_spec.js
@@ -50,7 +50,10 @@ describe('Ping Collector', async function () {
 
     it('writes ping to table', async function () {
         const result = await sendPing({
-            instanceId: 'test-instance'
+            instanceId: 'test-instance',
+            os: {
+                type: 'linux'
+            }
         })
         assert.equal(result.statusCode, 200)
         assert.deepEqual(result.body, {"status": "success"})
@@ -58,10 +61,11 @@ describe('Ping Collector', async function () {
         assert.equal(pings.length, 1)
         const ping = pings[0]
         assert.equal(ping.instanceId, 'test-instance')
+        assert.equal(ping['os.type'], 'linux')
         assert.ok(ping.ip)
         assert.notEqual(ping.ip, '192.168.0.1')
         // Check createdAt is within last 500ms
-        assert.ok(Date.now() - ping.createdAt.getTime() < 500)
+        assert.ok(Date.now() - ping.created_at.getTime() < 500)
 
     })
 


### PR DESCRIPTION
## Description

This PR starts migrating this project to a more PG friendly schema. This initial change is aimed at two things:
1. Remove mixed case column names: PG doesn't like it, and querying the data becomes slightly harder. Further, the lack of a standard of column names makes wrangling the data slightly harder
2. Remove columns we don't need: If we have a proper timestamp the query itself can group by week. No need to store it in a column. Mostly these items will end up a materialised view anyway, no need to store them twice.

To keep the scope somewhat contained, I wanted to start off small. Though I'll likely soon follow up with a PR that moves all other columns to using underscores instead of mixed case and give integer columns a default too.

## Checklist

 - [X] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [X] Includes a DB migration? -> add the `area:migration` label

