### PR TITLE
Add unit test setup for ping collector

### DIFF
--- a/.github/workflows/test-postgresql.yml
+++ b/.github/workflows/test-postgresql.yml
@@ -1,0 +1,44 @@
+name: Test Ping Collector
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  runner-job:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_PASSWORD: secret
+          POSTGRES_USER: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+    strategy:
+      matrix:
+        node-version: [16.x]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup NodeJS ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Dependencies
+        run: npm install
+      - name: Run tests
+        env:
+          PG_URL: localhost
+          PG_PORT: 5432
+          PG_USER: postgres
+          PG_PW: secret
+          PG_DB: pings_test
+        run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+node_modules
+package-lock.json
 src/node_modules
 function.zip

--- a/README.md
+++ b/README.md
@@ -60,3 +60,50 @@ This is currently done be running the appropriate `ALTER TABLE` commands on the
 database. The `database-schema.sql` file should also be updated as a record of
 the expected schema.
 
+## Testing the collector
+
+The tests in this repo can be used to verify the behaviour of the collector against
+a *local* Postgres database.
+
+### Running postgres locally
+
+The following will run postgress locally using Docker, with the default configuration
+used by the tests.
+
+You can use a different port/username/password/db, but will need to set some
+environment variables to tell the tests where to find postgres.
+
+```
+docker pull postgres
+docker run --name pingCollectorPostgres \
+    -p 5432:5432 \
+    -e POSTGRES_USER=postgres \
+    -e POSTGRES_PASSWORD=secret \
+    -e POSTGRES_DB=pings_test \
+    -d \
+    postgres
+```
+
+To later stop the container
+
+```
+docker stop pingCollectorPostgres
+```
+
+### Running the tests
+
+The tests expect the database to be running on `localhost:5432` with a username/password
+of `postgres`/`secret` and to use a database called `pings_test`.
+
+The following env vars can be set to change any of those properties:
+
+ - `PG_URL`
+ - `PG_DB`
+ - `PG_USER`
+ - `PG_PW`
+
+Finally, to run the tests:
+
+```
+npm run test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "usage-ping-collector",
+  "version": "1.0.0",
+  "description": "This repo contains the code for the FlowForge Telemetry Ping App. This is a very simple HTTPS end point that is used to collect usage information from instances of FlowForge that have opted-in to sharing the information.",
+  "private": true,
+  "scripts": {
+    "test": "mocha test/**/*_spec.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/flowforge/usage-ping-collector.git"
+  },
+  "keywords": [],
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/flowforge/usage-ping-collector/issues"
+  },
+  "homepage": "https://github.com/flowforge/usage-ping-collector#readme",
+  "devDependencies": {
+    "mocha": "^10.2.0",
+    "pg": "^8.8.0"
+  }
+}

--- a/src/app.js
+++ b/src/app.js
@@ -127,6 +127,7 @@ exports.handler = async (event, context) => {
 
             const dbConfig = {
                 host: process.env.PG_URL,
+                port: process.env.PG_PORT || '5432',
                 user: process.env.PG_USER,
                 password: process.env.PG_PW,
                 database: process.env.PG_DB,

--- a/test/app_spec.js
+++ b/test/app_spec.js
@@ -1,0 +1,68 @@
+const assert = require('node:assert').strict
+
+const db = require('./lib/db')
+
+const pingHandler = require('../src/app')
+
+async function sendPing (payload, toJSON = true) {
+    const event = {
+        requestContext: {
+            http: {
+                sourceIp: '192.168.0.1'
+            }
+        }
+    }
+    if (payload) {
+        event.body = toJSON ? JSON.stringify(payload) : payload
+    }
+    const result = await pingHandler.handler(event)
+    result.body = JSON.parse(result.body)
+    return result
+}
+
+
+describe('Ping Collector', async function () {
+    beforeEach(async function () {
+        return db.createDatabase()
+    })
+    it('connects to the db', async function () {
+        const pings = await db.getPings()
+        assert.equal(pings.length, 0)
+    })
+
+    it('rejects a ping missing a body', async function () {
+        const result = await sendPing()
+        assert.equal(result.statusCode, 400)
+        assert.deepEqual(result.body, {"status":"error","error":"Missing request body"})
+    })
+
+    it('rejects a ping missing an instanceId', async function () {
+        const result = await sendPing({})
+        assert.equal(result.statusCode, 400)
+        assert.deepEqual(result.body, {"status":"error","error":"Error: Missing required property: instanceId"})
+    })
+
+    it('rejects non-json payload', async function () {
+        const result = await sendPing('this is not json', false)
+        assert.equal(result.statusCode, 400)
+        assert.match(result.body.error, /SyntaxError/)
+    })
+
+    it('writes ping to table', async function () {
+        const result = await sendPing({
+            instanceId: 'test-instance'
+        })
+        assert.equal(result.statusCode, 200)
+        assert.deepEqual(result.body, {"status": "success"})
+        const pings = await db.getPings()
+        assert.equal(pings.length, 1)
+        const ping = pings[0]
+        assert.equal(ping.instanceId, 'test-instance')
+        assert.ok(ping.ip)
+        assert.notEqual(ping.ip, '192.168.0.1')
+        // Check createdAt is within last 500ms
+        assert.ok(Date.now() - ping.createdAt.getTime() < 500)
+
+    })
+
+})

--- a/test/lib/db.js
+++ b/test/lib/db.js
@@ -1,0 +1,73 @@
+const { readFile } = require('node:fs/promises')
+const path = require('node:path')
+const { Client } = require('pg')
+
+process.env.PG_DB = process.env.PG_DB || 'pings_test'
+process.env.PG_URL = process.env.PG_URL || 'localhost'
+process.env.PG_PORT = process.env.PG_PORT || '5432'
+process.env.PG_USER = process.env.PG_USER || 'postgres'
+process.env.PG_PW = process.env.PG_PW || 'secret'
+
+const PG_OPTS = {
+    host: process.env.PG_URL,
+    port: process.env.PG_PORT,
+    user: process.env.PG_USER,
+    password: process.env.PG_PW
+}
+
+// Lets be very careful about what we run against
+if (/amazonaws.com/.test(process.env.PG_URL)) {
+    console.log('It looks like you are running against the live database.')
+    console.log('Do not do that. Setup a local PG instance')
+    process.exit(1)
+}
+
+async function createDatabase () {
+    const client = new Client(PG_OPTS)
+    await client.connect()
+    try {
+        await client.query(`DROP DATABASE ${process.env.PG_DB}`)
+    } catch (err) {
+        // Don't mind if it doesn't exist
+    }
+    await client.query(`CREATE DATABASE ${process.env.PG_DB}`)
+    await client.end()
+    await createTable()
+}
+
+async function query(queryFunction) {
+    const client = new Client({
+        ...PG_OPTS,
+        database: process.env.PG_DB
+    })
+    await client.connect()
+    try {
+        return await queryFunction(client)
+    } catch (err) {
+        console.log(err)
+        throw err
+    } finally {
+        client.end()
+    }
+}
+
+
+async function createTable () {
+    await query(async (client) => {
+        const schema = await readFile(path.join(__dirname, '..', '..', 'database-schema.sql'), 'utf-8')
+        await client.query(schema)
+    })
+}
+
+async function getPings () {
+    return query(async (client) => {
+        const result = await client.query('SELECT * from pings')
+        return result.rows
+    })
+}
+
+module.exports = {
+    createDatabase,
+    query,
+    getPings
+}


### PR DESCRIPTION
## Description

Adds unit tests for the ping collector.

The previous collector was hard to unit test locally as it expected to be able to magically write to DynamoDB from the lambda. The new collector is much easier to test as it writes to a database that can be configured via env vars.

This is a very minimal set of tests - just getting the basic infrastructure in place. Want to get this merged before we start refactoring too much so we can keep the tests up to date.


## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

