### PR TITLE
Add library counts and improve testing of migrations

### DIFF
--- a/database-schema.sql
+++ b/database-schema.sql
@@ -20,5 +20,7 @@ CREATE TABLE "pings" (
    "platform.config.broker.enabled" BOOLEAN,
    "platform.config.email.enabled" BOOLEAN,
    "platform.config.fileStore.enabled" BOOLEAN,
+   "platform.counts.libraryEntries" INTEGER,
+   "platform.counts.sharedLibraryEntries" INTEGER,
    PRIMARY KEY ("created_at", "instanceId")
 )

--- a/migrations/00000000-create-table.sql
+++ b/migrations/00000000-create-table.sql
@@ -1,0 +1,25 @@
+--- This creates the pings table
+CREATE TABLE "pings" (
+   "createdAt" TIMESTAMP not null,
+   "weekYear" varchar(12),
+   "weekStartDate" TIMESTAMP,
+   "instanceId" varchar(256),
+   "ip" varchar(256),
+   "isDev" BOOLEAN,
+   "env.flowforge" varchar(64),
+   "env.nodejs" varchar(64),
+   "os.arch" varchar(32),
+   "os.release" varchar(128),
+   "os.type" varchar(32),
+   "platform.config.driver" varchar(32),
+   "platform.counts.projects" INTEGER,
+   "platform.counts.teams" INTEGER,
+   "platform.counts.users" INTEGER,
+   "platform.counts.devices" INTEGER,
+   "platform.counts.projectSnapshots" INTEGER,
+   "platform.counts.projectStacks" INTEGER,
+   "platform.counts.projectTemplates" INTEGER,
+   "platform.config.broker.enabled" BOOLEAN,
+   "platform.config.email.enabled" BOOLEAN,
+   "platform.config.fileStore.enabled" BOOLEAN
+)

--- a/migrations/20230107-add-primary-key.sql
+++ b/migrations/20230107-add-primary-key.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "pings" ADD PRIMAY KEY ("created_at", "instanceId");
+ALTER TABLE "pings" ADD PRIMARY KEY ("created_at", "instanceId");

--- a/migrations/20230117-add-library-counts.sql
+++ b/migrations/20230117-add-library-counts.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "pings" ADD "platform.counts.libraryEntries" INTEGER;
+ALTER TABLE "pings" ADD "platform.counts.sharedLibraryEntries" INTEGER;

--- a/src/app.js
+++ b/src/app.js
@@ -26,7 +26,9 @@ const optionalProperties = [
     'platform.config.driver',
     'platform.config.broker.enabled',
     'platform.config.fileStore.enabled',
-    'platform.config.email.enabled'
+    'platform.config.email.enabled',
+    'platform.counts.libraryEntries',
+    'platform.counts.sharedLibraryEntries'
 ]
 
 const dbColumns = [


### PR DESCRIPTION
Fixes #18 

 - Fixs typo in migration file
 - Uses the migrations when constructing the database in the tests
 - Adds
    - `platform.counts.libraryEntries`
    - `platform.counts.sharedLibraryEntries`

